### PR TITLE
2555: Desconsidera alteração na URN fragmento no processo de nomeação

### DIFF
--- a/src/test/scala/br/gov/lexml/urnformatter/Uren2NomeTest.scala
+++ b/src/test/scala/br/gov/lexml/urnformatter/Uren2NomeTest.scala
@@ -26,6 +26,8 @@ class Uren2NomeTest extends TestCase {
     
     assertEquals("item 1", Urn2Nome.format("ite_1"))
 
+    assertEquals("artigo 223-A do caput do artigo 1º", Urn2Nome.format("art1_cpt_alt1_art223-1"))
+
 
   }
 


### PR DESCRIPTION
@laurocesar , o problema da 2555 parece ser na lib de nomeação, que não exclui a parte `alt1` no processo de nomeação. 

O teste que adicionei está falhando com:

```
junit.framework.ComparisonFailure: 
Expected :artigo 223-A do caput do artigo 1º
Actual   :artigo 223-A da alteração do caput do artigo 1º
```